### PR TITLE
Integrar ingestión de alertas con APIs de medios y redes

### DIFF
--- a/apps/base/api/ingestion.py
+++ b/apps/base/api/ingestion.py
@@ -43,9 +43,9 @@ class IngestionAPIView(APIView):
     authentication_classes: list = []
     permission_classes: list = []
     provider_endpoints = {
-        "medios_twk": "ingestion",
-        "redes_twk": "ingestion",
-        "determ": "ingestion",
+        "medios_twk": "medios-alertas-ingestion",
+        "redes_twk": "redes-alertas-ingestion",
+        "determ": "redes-alertas-ingestion",
     }
 
     def post(self, request):
@@ -58,10 +58,10 @@ class IngestionAPIView(APIView):
         if not proyecto:
             return Response({"detail": "Proyecto no encontrado."}, status=404)
 
-        if 'file' not in request.FILES:
+        if "file" not in request.FILES and "archivo" not in request.FILES:
             return Response({"detail": "Se requiere un archivo."}, status=400)
 
-        archivo = request.FILES['file']
+        archivo = request.FILES.get("file") or request.FILES.get("archivo")
 
         extension = os.path.splitext(archivo.name)[1].lower()
         if extension not in {".csv", ".xlsx"}:
@@ -155,11 +155,12 @@ class IngestionAPIView(APIView):
 
     def _map_medios_twk(self, row: Dict) -> Dict:
         return {
-            "title": row.get("title"),
-            "content": row.get("content"),
-            "published": row.get("published"),
-            "autor_name": row.get("extra_author_attributes.name"),
+            "titulo": row.get("title"),
+            "contenido": row.get("content"),
+            "fecha": row.get("published"),
+            "autor": row.get("extra_author_attributes.name"),
             "reach": row.get("reach"),
+            "url": row.get("url") or row.get("link"),
         }
 
     def _map_redes_twk(self, row: Dict) -> Dict:
@@ -167,8 +168,10 @@ class IngestionAPIView(APIView):
             "contenido": row.get("content"),
             "fecha": row.get("published"),
             "autor": row.get("extra_author_attributes.name"),
-            "alcance": row.get("reach"),
-            "engammet": row.get("engagement"),
+            "reach": row.get("reach"),
+            "engagement": row.get("engagement"),
+            "url": row.get("url") or row.get("link"),
+            "red_social": row.get("red_social"),
         }
 
     def _map_determ(self, row: Dict) -> Dict:
@@ -177,8 +180,10 @@ class IngestionAPIView(APIView):
             "contenido": row.get("MENTION_SNIPPET"),
             "fecha": fecha,
             "reach": row.get("REACH"),
-            "engagement_rate": row.get("ENGAGEMENT_RATE"),
+            "engagement": row.get("ENGAGEMENT_RATE"),
             "autor": row.get("AUTHOR"),
+            "url": row.get("URL"),
+            "red_social": row.get("SOCIAL_NETWORK"),
         }
 
     def _combine_fecha(self, fecha_value, hora_value) -> str:

--- a/apps/base/tests/test_ingestion.py
+++ b/apps/base/tests/test_ingestion.py
@@ -52,7 +52,7 @@ class IngestionAPITests(SimpleTestCase):
         self.assertEqual(payload["proveedor"], "medios_twk")
         self.assertEqual(payload["proyecto"], self.proyecto_id)
         self.assertEqual(len(payload["alertas"]), 1)
-        self.assertEqual(payload["alertas"][0]["autor_name"], "Autor")
+        self.assertEqual(payload["alertas"][0]["autor"], "Autor")
 
     @patch("apps.base.api.ingestion.Proyecto")
     def test_detects_redes_twk_from_xlsx_and_forwards_payload(self, mock_proyecto):
@@ -101,4 +101,4 @@ class IngestionAPITests(SimpleTestCase):
         self.assertEqual(len(payload["alertas"]), 1)
         alerta = payload["alertas"][0]
         self.assertEqual(alerta["contenido"], "Hola")
-        self.assertEqual(alerta["engammet"], "42")
+        self.assertEqual(alerta["engagement"], "42")

--- a/apps/base/urls.py
+++ b/apps/base/urls.py
@@ -24,10 +24,12 @@ urlpatterns = [
 
 
     path('redes/importar-redes/', ImportarRedesAPIView.as_view(), name='importar-redes'),
+    path('redes/ingestion/', ImportarRedesAPIView.as_view(), name='redes-alertas-ingestion'),
     path('redes/', RedesListAPIView.as_view(), name='redes-list'),
     path("redes/<uuid:pk>/", RedesUpdateAPIView.as_view(), name="redes-update"),
 
     path('medios/importar-articulos/', ImportarArticuloAPIView.as_view(), name='importar-articulo'),
+    path('medios/ingestion/', ImportarArticuloAPIView.as_view(), name='medios-alertas-ingestion'),
     path('medios/', MediosListAPIView.as_view(), name='medios-list'),
     path("medios/<uuid:pk>/", MediosUpdateAPIView.as_view(), name="update-medio"),
     path("ingestion/", IngestionAPIView.as_view(), name="ingestion"),


### PR DESCRIPTION
## Summary
- enruta la IngestionAPIView hacia nuevos endpoints internos diferenciados para medios y redes y mejora el mapeo de campos de alertas
- actualiza las APIs de importación de medios y redes para aceptar la nueva estructura `alertas` y reutilizarla en los envíos automáticos
- expone rutas de ingestión para medios y redes y ajusta las pruebas para validar la nueva estructura de datos

## Testing
- python manage.py test apps.base.tests.test_ingestion

------
https://chatgpt.com/codex/tasks/task_e_68d17e6792808333ba9e76845e71a022