### PR TITLE
Ajusta recorte de contenido de Twitter en ingestion

### DIFF
--- a/apps/base/api/contenido_redes.py
+++ b/apps/base/api/contenido_redes.py
@@ -1,0 +1,33 @@
+"""Utilidades para el procesamiento de contenido de redes sociales."""
+from __future__ import annotations
+
+from typing import Optional
+
+
+_TWITTER_NAMES = {"twitter", "x"}
+_KEYWORDS = ("QT", "Repost")
+
+
+def ajustar_contenido_red_social(contenido: Optional[str], red_social: Optional[str]) -> Optional[str]:
+    """Recorta el contenido cuando corresponde a publicaciones de Twitter/X con QT o Repost."""
+    if not contenido:
+        return contenido
+
+    red = (red_social or "").strip().lower()
+    if red not in _TWITTER_NAMES:
+        return contenido.strip()
+
+    texto = contenido
+    texto_normalizado = texto.upper()
+    cortes = []
+
+    for palabra in _KEYWORDS:
+        indice = texto_normalizado.find(palabra.upper())
+        if indice != -1:
+            cortes.append((indice, len(palabra)))
+
+    if not cortes:
+        return texto.strip()
+
+    indice, longitud = min(cortes, key=lambda item: item[0])
+    return texto[: indice + longitud].strip()


### PR DESCRIPTION
## Resumen
- agrega el helper `ajustar_contenido_red_social` para recortar publicaciones de Twitter/X cuando contienen QT o Repost
- aplica el recorte en la ingesta manual y automática de redes sociales, incluyendo fuentes TWK y Determ
- extiende la suite de pruebas de ingestión para cubrir el nuevo comportamiento

## Pruebas
- python manage.py test apps.base.tests.test_ingestion

------
https://chatgpt.com/codex/tasks/task_e_68d1e9c41e948333aadcc809bb9d3235