### PR TITLE
Crear plantilla automática al crear proyecto

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -1,0 +1,48 @@
+"""Utilidades comunes para la aplicación base."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional
+
+from django.db import models
+
+
+def generar_plantilla_desde_modelo(
+    model: type[models.Model],
+    campos_excluir: Optional[Iterable[str]] = None,
+) -> Dict[str, Dict[str, object]]:
+    """Genera una configuración de plantilla a partir de un modelo.
+
+    Parameters
+    ----------
+    model:
+        Clase del modelo de Django del cual se obtendrán los campos.
+    campos_excluir:
+        Colección de nombres de campos que se deben omitir en la plantilla.
+
+    Returns
+    -------
+    dict
+        Diccionario donde las claves son los nombres de los campos y los
+        valores contienen la información de orden y estilo utilizada por la
+        configuración de plantillas.
+    """
+
+    campos_excluir = set(campos_excluir or [])
+
+    campos_config: Dict[str, Dict[str, object]] = {}
+    indice = 1
+
+    for field in model._meta.get_fields():
+        if not getattr(field, "concrete", False):
+            continue
+        if getattr(field, "auto_created", False):
+            continue
+        if field.name in campos_excluir:
+            continue
+
+        campos_config[field.name] = {"orden": indice, "estilo": {}}
+        indice += 1
+
+    return campos_config
+

--- a/apps/proyectos/serializers/proyecto_serializer.py
+++ b/apps/proyectos/serializers/proyecto_serializer.py
@@ -1,9 +1,13 @@
 from rest_framework import serializers
+from django.db import transaction
+
 from apps.proyectos.models import Proyecto
+from apps.base.models import TemplateConfig, Articulo, Redes
+from apps.base.utils import generar_plantilla_desde_modelo
 
 
 class ProyectoCreateSerializer(serializers.ModelSerializer):
-    # grupo_nombre = serializers.CharField(read_only=True) 
+    # grupo_nombre = serializers.CharField(read_only=True)
 
     class Meta:
         model = Proyecto
@@ -28,6 +32,45 @@ class ProyectoCreateSerializer(serializers.ModelSerializer):
         if Proyecto.objects.filter(nombre=value).exists():
             raise serializers.ValidationError("Ya existe un proyecto con este nombre.")
         return value
+
+    def create(self, validated_data):
+        with transaction.atomic():
+            proyecto = Proyecto.objects.create(**validated_data)
+            self._crear_plantilla_por_defecto(proyecto)
+        return proyecto
+
+    def _crear_plantilla_por_defecto(self, proyecto: Proyecto) -> None:
+        mapping = {
+            "medios": (Articulo, "Plantilla Medios"),
+            "redes": (Redes, "Plantilla Redes"),
+        }
+
+        modelo_config = mapping.get(proyecto.tipo_alerta)
+        if not modelo_config:
+            return
+
+        model, nombre = modelo_config
+        config_campos = generar_plantilla_desde_modelo(
+            model,
+            campos_excluir={
+                "id",
+                "created_at",
+                "modified_at",
+                "created_by",
+                "modified_by",
+                "proyecto",
+            },
+        )
+
+        TemplateConfig.objects.get_or_create(
+            proyecto=proyecto,
+            app_label=model._meta.app_label,
+            model_name=model._meta.model_name,
+            defaults={
+                "nombre": nombre,
+                "config_campos": config_campos,
+            },
+        )
 
 
 class ProyectoUpdateSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Summary
- crear una utilidad que genera configuraciones de plantilla a partir de los campos de un modelo
- generar automáticamente la plantilla inicial del proyecto al momento de crearlo según su tipo de alerta

## Testing
- python manage.py test


------
https://chatgpt.com/codex/tasks/task_e_68d306b1d97c833384b012b1e9be6444