### PR TITLE
Guardar todos los atributos de campos de plantilla

### DIFF
--- a/apps/base/api/formato_mensaje.py
+++ b/apps/base/api/formato_mensaje.py
@@ -52,11 +52,15 @@ class CrearCamposPlantillaAPIView(APIView):
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
-            # Actualizamos o creamos configuración
-            config_actual[nombre_campo] = {
-                "orden": campo.get("orden", config_actual.get(nombre_campo, {}).get("orden")),
-                "estilo": campo.get("estilo", config_actual.get(nombre_campo, {}).get("estilo", {}))
-            }
+            config_existente = config_actual.get(nombre_campo, {})
+            nueva_config = config_existente.copy()
+
+            for clave, valor in campo.items():
+                if clave == "campo":
+                    continue
+                nueva_config[clave] = valor
+
+            config_actual[nombre_campo] = nueva_config
 
         # Guardamos en la plantilla
         plantilla.config_campos = config_actual


### PR DESCRIPTION
## Summary
- actualizar el guardado de campos de plantilla para reutilizar la configuracion previa
- almacenar todos los atributos recibidos para cada campo, incluyendo estilos y etiquetas

## Testing
- python -m compileall apps/base/api/formato_mensaje.py

------
https://chatgpt.com/codex/tasks/task_e_68d462c7031c8333afc620cb4a1bbe1a