### PR TITLE
Handle ingestion files provided under different keys

### DIFF
--- a/apps/base/api/ingestion.py
+++ b/apps/base/api/ingestion.py
@@ -263,10 +263,21 @@ class IngestionAPIView(APIView):
             return archivos
 
         if hasattr(files, "getlist"):
-            for key in ("file", "archivo"):
-                archivos.extend([archivo for archivo in files.getlist(key) if archivo])
+            keys = list(getattr(files, "keys", lambda: [])())  # type: ignore[misc]
+            if not keys:
+                keys = ["file", "archivo"]
+
+            for key in keys:
+                for archivo in files.getlist(key):
+                    if archivo:
+                        archivos.append(archivo)
         else:
-            for key in ("file", "archivo"):
+            posibles_claves = set()
+            if hasattr(files, "keys"):
+                posibles_claves.update(files.keys())  # type: ignore[attr-defined]
+            posibles_claves.update({"file", "archivo"})
+
+            for key in posibles_claves:
                 archivo = files.get(key)
                 if archivo:
                     archivos.append(archivo)

--- a/apps/base/tests/test_ingestion.py
+++ b/apps/base/tests/test_ingestion.py
@@ -330,6 +330,58 @@ class IngestionAPITests(SimpleTestCase):
         self.assertEqual(response.data["mensaje"], "2 registros creados")
 
     @patch("apps.base.api.ingestion.Proyecto")
+    def test_permite_archivos_en_claves_distintas(self, mock_proyecto):
+        self._mock_proyecto(mock_proyecto)
+        contenido_a = (
+            "title,content,published,extra_author_attributes.name,reach\n"
+            "Titulo A,Contenido A,2024-03-03,Autor A,1500\n"
+        )
+        contenido_b = (
+            "title,content,published,extra_author_attributes.name,reach\n"
+            "Titulo B,Contenido B,2024-04-04,Autor B,800\n"
+        )
+        archivo_a = SimpleUploadedFile(
+            "medios-a.csv",
+            contenido_a.encode("utf-8"),
+            content_type="text/csv",
+        )
+        archivo_b = SimpleUploadedFile(
+            "medios-b.csv",
+            contenido_b.encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        request = self.factory.post(
+            f"/api/ingestion/?proyecto={self.proyecto_id}",
+            {"archivo": archivo_a, "archivo_secundario": archivo_b},
+            format="multipart",
+        )
+
+        with patch.object(
+            IngestionAPIView,
+            "_obtener_usuario_sistema",
+            return_value=SimpleNamespace(id=2),
+        ), patch.object(
+            IngestionAPIView,
+            "_crear_articulo",
+            side_effect=self._fake_crear_articulo,
+        ), patch.object(
+            IngestionAPIView,
+            "_crear_red_social",
+            side_effect=self._fake_crear_red_social,
+        ):
+            response = IngestionAPIView.as_view()(request)
+
+        self.assertEqual(response.status_code, 201)
+        listado = response.data["listado"]
+        self.assertEqual(len(listado), 2)
+        autores = {alerta["autor"] for alerta in listado}
+        self.assertSetEqual(autores, {"Autor A", "Autor B"})
+        self.assertEqual(response.data["duplicados"], 0)
+        self.assertEqual(response.data["descartados"], 0)
+        self.assertEqual(response.data["mensaje"], "2 registros creados")
+
+    @patch("apps.base.api.ingestion.Proyecto")
     def test_aplica_filtro_de_criterios_de_aceptacion(self, mock_proyecto):
         self._mock_proyecto(mock_proyecto, criterios=["alerta"])
         content = (


### PR DESCRIPTION
## Summary
- update ingestion file collection to include uploads provided under any form key
- add coverage to ensure multiple independent upload fields are ingested together

## Testing
- python manage.py test apps.base.tests.test_ingestion

------
https://chatgpt.com/codex/tasks/task_e_68d6d41ca97c833390b51e06c85b89a4