### PR TITLE
Ensure ingestion handles multiple uploaded files

### DIFF
--- a/apps/base/api/ingestion.py
+++ b/apps/base/api/ingestion.py
@@ -257,19 +257,35 @@ class IngestionAPIView(APIView):
         return Proyecto.objects.filter(id=proyecto_id).first()
 
     def _obtener_archivos(self, request) -> List[Any]:
-        archivos: List[Any] = []
         files = getattr(request, "FILES", None)
         if not files:
-            return archivos
+            return []
 
-        if hasattr(files, "getlist"):
-            for key in ("file", "archivo"):
-                archivos.extend([archivo for archivo in files.getlist(key) if archivo])
+        archivos: List[Any] = []
+
+        def _agregar(valor: Any) -> None:
+            if not valor:
+                return
+            if isinstance(valor, (list, tuple, set)):
+                for item in valor:
+                    _agregar(item)
+                return
+            archivos.append(valor)
+
+        if hasattr(files, "lists"):
+            for _, valores in files.lists():  # type: ignore[attr-defined]
+                _agregar(valores)
+        elif hasattr(files, "values"):
+            for valor in files.values():  # type: ignore[attr-defined]
+                _agregar(valor)
         else:
-            for key in ("file", "archivo"):
-                archivo = files.get(key)
-                if archivo:
-                    archivos.append(archivo)
+            _agregar(files)
+
+        if not archivos and hasattr(files, "get"):
+            for clave in ("file", "archivo", "archivos", "files"):
+                valor = files.get(clave)  # type: ignore[attr-defined]
+                if valor:
+                    _agregar(valor)
 
         archivos_unicos: List[Any] = []
         vistos = set()


### PR DESCRIPTION
## Summary
- expand ingestion file extraction to gather every uploaded file regardless of the request.FILES container implementation
- cover the new extraction behaviour with focused unit tests that validate MultiValueDict and plain dict sources

## Testing
- python manage.py test apps.base.tests.test_ingestion

------
https://chatgpt.com/codex/tasks/task_e_68d6d41ca97c833390b51e06c85b89a4