### PR TITLE
Ordenar cronológicamente alertas en EnviarMensajeAPIView

### DIFF
--- a/apps/whatsapp/api/enviar_mensaje.py
+++ b/apps/whatsapp/api/enviar_mensaje.py
@@ -15,6 +15,8 @@ from apps.base.models import DetalleEnvio, Articulo, Redes, TemplateConfig
 from apps.proyectos.models import Proyecto
 from django.contrib.auth import get_user_model
 
+from apps.whatsapp.utils import ordenar_alertas_por_fecha
+
 
 logger = logging.getLogger(__name__)
 
@@ -429,6 +431,8 @@ class EnviarMensajeAPIView(APIView):
 
         enviados = []
         no_enviados = []
+
+        alertas = ordenar_alertas_por_fecha(alertas)
 
         for alerta in alertas:
             alerta_id = alerta.get("id")

--- a/apps/whatsapp/utils.py
+++ b/apps/whatsapp/utils.py
@@ -1,0 +1,47 @@
+"""Utilidades para el módulo de WhatsApp."""
+from __future__ import annotations
+
+from datetime import datetime, timezone as dt_timezone
+from typing import Iterable, List, MutableMapping, Sequence
+
+from django.utils.dateparse import parse_datetime
+
+
+def _obtener_fecha(alerta: MutableMapping, *, campo_fecha: str, campo_respaldo: str) -> datetime:
+    """Obtiene la fecha de la alerta intentando diferentes formatos."""
+    valor = alerta.get(campo_fecha) or alerta.get(campo_respaldo)
+
+    if isinstance(valor, datetime):
+        if valor.tzinfo is None:
+            return valor.replace(tzinfo=dt_timezone.utc)
+        return valor
+
+    if isinstance(valor, str) and valor:
+        fecha = parse_datetime(valor)
+        if fecha:
+            if fecha.tzinfo is None:
+                return fecha.replace(tzinfo=dt_timezone.utc)
+            return fecha
+        try:
+            return datetime.fromisoformat(valor.replace("Z", "+00:00"))
+        except ValueError:
+            pass
+
+    return datetime.min.replace(tzinfo=dt_timezone.utc)
+
+
+def ordenar_alertas_por_fecha(
+    alertas: Sequence[MutableMapping] | Iterable[MutableMapping],
+    *,
+    campo_fecha: str = "fecha_publicacion",
+    campo_respaldo: str = "fecha",
+) -> List[MutableMapping]:
+    """Devuelve las alertas ordenadas de la más reciente a la más antigua."""
+
+    alertas_lista = list(alertas or [])
+
+    return sorted(
+        alertas_lista,
+        key=lambda alerta: _obtener_fecha(alerta, campo_fecha=campo_fecha, campo_respaldo=campo_respaldo),
+        reverse=True,
+    )


### PR DESCRIPTION
## Summary
- crea una utilidad para normalizar y ordenar alertas según su fecha de publicación
- usa la nueva utilidad en EnviarMensajeAPIView para enviar los mensajes del más reciente al más antiguo

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6d6b1fa80833381814b52ab7cd01a