### PR TITLE
Include project name in ingestion responses

### DIFF
--- a/apps/base/api/ingestion.py
+++ b/apps/base/api/ingestion.py
@@ -207,6 +207,7 @@ class IngestionAPIView(APIView):
             "duplicados": 0,
             "descartados": 0,
             "proyecto_keywords": self._obtener_keywords_proyecto(proyecto),
+            "proyecto_nombre": self._obtener_nombre_proyecto(proyecto),
         }
 
     def _construir_respuesta_exito(
@@ -238,6 +239,7 @@ class IngestionAPIView(APIView):
             "duplicados": duplicados,
             "descartados": descartados,
             "proyecto_keywords": self._obtener_keywords_proyecto(proyecto),
+            "proyecto_nombre": self._obtener_nombre_proyecto(proyecto),
         }
 
     # ------------------------------------------------------------------
@@ -545,6 +547,16 @@ class IngestionAPIView(APIView):
             ]
 
         return []
+
+    def _obtener_nombre_proyecto(self, proyecto: Optional[Proyecto]) -> str:
+        if not proyecto:
+            return ""
+
+        nombre = getattr(proyecto, "nombre", "")
+        if not nombre:
+            return ""
+
+        return str(nombre)
 
     def _construir_payload_forward(
         self,


### PR DESCRIPTION
## Summary
- add the project name to ingestion API responses together with the existing keyword list
- provide a helper that safely extracts the project name from Proyecto instances
- update ingestion API tests to mock the project name and verify it is returned for success and empty-result flows

## Testing
- python manage.py test apps.base.tests.test_ingestion

------
https://chatgpt.com/codex/tasks/task_e_68dab8667f708333879624bb93f8d14c