### PR TITLE
Ordenar alertas cronologicamente

### DIFF
--- a/apps/whatsapp/utils.py
+++ b/apps/whatsapp/utils.py
@@ -36,12 +36,11 @@ def ordenar_alertas_por_fecha(
     campo_fecha: str = "fecha_publicacion",
     campo_respaldo: str = "fecha",
 ) -> List[MutableMapping]:
-    """Devuelve las alertas ordenadas de la más reciente a la más antigua."""
+    """Devuelve las alertas ordenadas de la más antigua a la más reciente."""
 
     alertas_lista = list(alertas or [])
 
     return sorted(
         alertas_lista,
         key=lambda alerta: _obtener_fecha(alerta, campo_fecha=campo_fecha, campo_respaldo=campo_respaldo),
-        reverse=True,
     )


### PR DESCRIPTION
## Summary
- Actualicé `ordenar_alertas_por_fecha` para ordenar la lista de alertas de la más antigua a la más reciente.

## Testing
- No se ejecutaron pruebas (non-applicable).

------
https://chatgpt.com/codex/tasks/task_e_68dac2209bec833383250c63e7cbf668