### PR TITLE
Aplicar formato de negrita a las etiquetas de mensajes

### DIFF
--- a/apps/whatsapp/api/enviar_mensaje.py
+++ b/apps/whatsapp/api/enviar_mensaje.py
@@ -50,10 +50,18 @@ def _aplicar_estilos(
     """Aplica los estilos soportados por la plantilla al valor recibido."""
 
     valor_base = valor
+    etiqueta_str = None
+    etiqueta_formateada = None
+
+    if etiqueta is not None:
+        etiqueta_str = str(etiqueta)
+        etiqueta_formateada = etiqueta_str
 
     if estilo:
         if estilo.get("negrita"):
             valor_base = f"*{valor_base}*"
+            if etiqueta_formateada is not None:
+                etiqueta_formateada = f"*{etiqueta_formateada}*"
         if estilo.get("inclinado"):
             valor_base = f"_{valor_base}_"
 
@@ -61,10 +69,9 @@ def _aplicar_estilos(
 
     valor_formateado = valor_base
 
-    if etiqueta:
-        etiqueta_str = str(etiqueta)
-        separador = "" if etiqueta_str.endswith((" ", "\t", "\n")) else ": "
-        valor_formateado = f"{etiqueta_str}{separador}{valor_formateado}"
+    if etiqueta_formateada is not None and etiqueta_str is not None:
+        separador = "" if etiqueta_str.endswith((" ", "\t", "\n")) else ": ""
+        valor_formateado = f"{etiqueta_formateada}{separador}{valor_formateado}"
 
     return valor_formateado, salto_linea
 


### PR DESCRIPTION
## Summary
- aplicar el mismo estilo de negrita a las etiquetas cuando la plantilla lo requiere

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dacc2e5444833382423706071c16a1