### PR TITLE
Evitar dos puntos con etiquetas sin contenido

### DIFF
--- a/apps/whatsapp/api/enviar_mensaje.py
+++ b/apps/whatsapp/api/enviar_mensaje.py
@@ -50,21 +50,35 @@ def _aplicar_estilos(
     """Aplica los estilos soportados por la plantilla al valor recibido."""
 
     valor_base = valor
+    etiqueta_str = None
+    etiqueta_formateada = None
+
+    if etiqueta is not None:
+        etiqueta_str = str(etiqueta)
+        if etiqueta_str.strip():
+            etiqueta_formateada = etiqueta_str
+        else:
+            etiqueta_str = None
 
     if estilo:
         if estilo.get("negrita"):
             valor_base = f"*{valor_base}*"
+            if etiqueta_formateada is not None:
+                etiqueta_formateada = f"*{etiqueta_formateada}*"
         if estilo.get("inclinado"):
             valor_base = f"_{valor_base}_"
+            if etiqueta_formateada is not None:
+                etiqueta_formateada = f"_{etiqueta_formateada}_"
 
     salto_linea = estilo.get("salto_linea") if estilo else None
 
     valor_formateado = valor_base
 
-    if etiqueta:
-        etiqueta_str = str(etiqueta)
-        separador = "" if etiqueta_str.endswith((" ", "\t", "\n")) else ": "
-        valor_formateado = f"{etiqueta_str}{separador}{valor_formateado}"
+    if etiqueta_formateada is not None and etiqueta_str is not None:
+        etiqueta_visible = etiqueta_formateada.replace("*", "").replace("_", "").strip()
+        if etiqueta_visible:
+            separador = "" if etiqueta_str.endswith((" ", "\t", "\n")) else ": "
+            valor_formateado = f"{etiqueta_formateada}{separador}{valor_formateado}"
 
     return valor_formateado, salto_linea
 


### PR DESCRIPTION
## Summary
- evita agregar el separador cuando la etiqueta formateada no deja texto visible

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68dacc2e5444833382423706071c16a1