### PR TITLE
Preserve zero values when importing social alerts

### DIFF
--- a/apps/base/api/importar_redes.py
+++ b/apps/base/api/importar_redes.py
@@ -182,13 +182,23 @@ class ImportarRedesAPIView(APIView):
         return list(redes)
 
     def _map_alerta_to_red(self, alerta: Dict[str, Any]) -> Dict[str, Any]:
+        reach = alerta.get("reach")
+        if reach is None:
+            reach = alerta.get("alcance")
+
+        engagement = alerta.get("engagement")
+        if engagement is None:
+            engagement = alerta.get("engammet")
+        if engagement is None:
+            engagement = alerta.get("engagement_rate")
+
         return {
             "contenido": alerta.get("contenido") or alerta.get("content"),
             "fecha": alerta.get("fecha") or alerta.get("published"),
             "url": alerta.get("url") or alerta.get("link"),
             "autor": alerta.get("autor") or alerta.get("autor_name"),
-            "reach": alerta.get("reach") or alerta.get("alcance"),
-            "engagement": alerta.get("engagement") or alerta.get("engammet") or alerta.get("engagement_rate"),
+            "reach": reach,
+            "engagement": engagement,
             "red_social": alerta.get("red_social") or alerta.get("social_network") or alerta.get("SOCIAL_NETWORK"),
         }
 

--- a/apps/base/tests/test_importar_redes.py
+++ b/apps/base/tests/test_importar_redes.py
@@ -1,0 +1,37 @@
+from django.test import SimpleTestCase
+
+from apps.base.api.importar_redes import ImportarRedesAPIView
+
+
+class ImportarRedesMapAlertasTests(SimpleTestCase):
+    def setUp(self):
+        self.view = ImportarRedesAPIView()
+
+    def test_reach_zero_is_preserved(self):
+        alerta = {"reach": 0, "alcance": 999}
+
+        resultado = self.view._map_alerta_to_red(alerta)
+
+        self.assertIn("reach", resultado)
+        self.assertEqual(resultado["reach"], 0)
+
+    def test_reach_uses_alternative_when_none(self):
+        alerta = {"reach": None, "alcance": 0}
+
+        resultado = self.view._map_alerta_to_red(alerta)
+
+        self.assertEqual(resultado["reach"], 0)
+
+    def test_engagement_zero_is_preserved(self):
+        alerta = {"engagement": 0, "engammet": 123, "engagement_rate": 456}
+
+        resultado = self.view._map_alerta_to_red(alerta)
+
+        self.assertEqual(resultado["engagement"], 0)
+
+    def test_engagement_falls_back_when_none(self):
+        alerta = {"engagement": None, "engammet": None, "engagement_rate": 7}
+
+        resultado = self.view._map_alerta_to_red(alerta)
+
+        self.assertEqual(resultado["engagement"], 7)


### PR DESCRIPTION
## Summary
- ensure the social alert importer keeps zero values for numeric fields instead of overwriting them with fallbacks
- add unit tests that verify zero and fallback behavior for reach and engagement mappings

## Testing
- python manage.py test apps.base.tests.test_importar_redes

------
https://chatgpt.com/codex/tasks/task_e_68dbe8da4c848333bbe52223373d9424