### PR TITLE
Preservar valores cero en parseo de enteros

### DIFF
--- a/apps/base/api/utils.py
+++ b/apps/base/api/utils.py
@@ -61,11 +61,22 @@ def limpiar_url(value: Any) -> Optional[str]:
 def parsear_entero(value: Any) -> Optional[int]:
     if value in (None, ""):
         return None
+
     try:
         if isinstance(value, str):
-            value = value.replace(",", "").strip()
+            valor_normalizado = value.replace(",", "").strip()
+            if valor_normalizado.endswith("%"):
+                valor_normalizado = valor_normalizado[:-1].strip()
+            value = valor_normalizado
         return int(float(value))
     except (TypeError, ValueError):
+        if isinstance(value, str):
+            valor_normalizado = value.replace(",", "").strip()
+            if valor_normalizado.endswith("%"):
+                valor_normalizado = valor_normalizado[:-1].strip()
+            solo_digitos = "".join(ch for ch in valor_normalizado if ch.isdigit())
+            if solo_digitos and set(solo_digitos) <= {"0"}:
+                return 0
         return None
 
 


### PR DESCRIPTION
## Summary
- normalizar cadenas en `parsear_entero` para permitir convertir valores con porcentaje
- conservar los valores igual a cero aunque contengan caracteres adicionales

## Testing
- python -m compileall apps/base/api/utils.py

------
https://chatgpt.com/codex/tasks/task_e_68dbedc9a95c8333a0402f5fd525e59b