### PR TITLE
Return 405 when ingestion has no accepted records

### DIFF
--- a/apps/base/api/ingestion.py
+++ b/apps/base/api/ingestion.py
@@ -153,7 +153,7 @@ class IngestionAPIView(APIView):
                 proyecto,
             )
             self._notificar_ruta_externa(respuesta)
-            return Response(respuesta, status=200)
+            return Response(respuesta, status=405)
 
         resultado = self._persistir_registros(registros_filtrados, proyecto)
         respuesta = self._construir_respuesta_exito(

--- a/apps/base/tests/test_ingestion.py
+++ b/apps/base/tests/test_ingestion.py
@@ -493,7 +493,7 @@ class IngestionAPITests(SimpleTestCase):
         ):
             response = IngestionAPIView.as_view()(request)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 405)
         self.assertEqual(response.data["proyecto_nombre"], "Proyecto Test")
 
     @patch("apps.base.api.ingestion.Proyecto")
@@ -849,7 +849,7 @@ class IngestionAPITests(SimpleTestCase):
         ) as mock_forward:
             response = IngestionAPIView.as_view()(request)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 405)
         mock_forward.assert_not_called()
         self.assertIn("mensaje", response.data)
         self.assertIn("criterios", response.data["mensaje"])


### PR DESCRIPTION
## Summary
- update the ingestion API to return HTTP 405 when no records meet the acceptance criteria
- adjust ingestion API tests to expect the new response status when no records are accepted

## Testing
- `python manage.py test apps.base.tests.test_ingestion.IngestionAPITests.test_respuesta_sin_registros_incluye_nombre apps.base.tests.test_ingestion.IngestionAPITests.test_filtro_de_criterios_sin_coincidencias_no_reenvia`


------
https://chatgpt.com/codex/tasks/task_e_68de8bbc1b648333a3df23c98ab5477d