### PR TITLE
Marcar detalles de envío como revisados durante la ingestión

### DIFF
--- a/apps/base/api/importar_medios.py
+++ b/apps/base/api/importar_medios.py
@@ -70,7 +70,7 @@ class ImportarArticuloAPIView(APIView):
             # Crear detalle de envío
             detalle_envio = DetalleEnvio.objects.create(
                 estado_enviado=False,
-                estado_revisado=False,
+                estado_revisado=True,
                 medio=articulo,
                 proyecto_id=proyecto.id
             )

--- a/apps/base/api/importar_redes.py
+++ b/apps/base/api/importar_redes.py
@@ -77,9 +77,9 @@ class ImportarRedesAPIView(APIView):
 
             detalle_envio = DetalleEnvio.objects.create(
                 estado_enviado=False,
-                estado_revisado=False,
+                estado_revisado=True,
                 red_social=red,
-                proyecto_id=proyecto.id 
+                proyecto_id=proyecto.id
             )
 
             creados.append({

--- a/apps/base/api/ingestion.py
+++ b/apps/base/api/ingestion.py
@@ -935,7 +935,7 @@ class IngestionAPIView(APIView):
 
             DetalleEnvio.objects.create(
                 estado_enviado=False,
-                estado_revisado=False,
+                estado_revisado=True,
                 medio=articulo,
                 proyecto=proyecto,
             )
@@ -997,7 +997,7 @@ class IngestionAPIView(APIView):
 
             DetalleEnvio.objects.create(
                 estado_enviado=False,
-                estado_revisado=False,
+                estado_revisado=True,
                 red_social=red,
                 proyecto=proyecto,
             )


### PR DESCRIPTION
## Summary
- actualiza la creación de DetalleEnvio durante la ingestión automática y manual para marcar `estado_revisado` en verdadero

## Testing
- no se ejecutaron pruebas


------
https://chatgpt.com/codex/tasks/task_e_68de9e6624988333ad4d248b7e666c3d