### PR TITLE
Ajustar pruebas de ingestión para fechas de Global News y Stakeholders

### DIFF
--- a/apps/base/tests/test_ingestion.py
+++ b/apps/base/tests/test_ingestion.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, time
 from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -498,6 +498,41 @@ class IngestionAPITests(SimpleTestCase):
         self.assertIsNotNone(registro["fecha"])
         self.assertEqual(registro["fecha"].date(), date(2024, 5, 10))
         self.assertEqual(registro["reach"], 2500)
+
+    def test_mapear_medios_global_news_soporta_formato_fecha_latam(self):
+        view = IngestionAPIView()
+        row = {
+            "titulo": "Titulo GN",
+            "contenido": "Contenido GN",
+            "fecha": "11/09/2025",
+            "autor": "Autor GN",
+            "audiencia": "1500",
+            "url": "http://example.com/global-news",
+        }
+
+        registro = view._mapear_medios_twk(row, "global_news")
+
+        self.assertIsNotNone(registro["fecha"])
+        self.assertEqual(registro["fecha"].date(), date(2025, 9, 11))
+        self.assertEqual(registro["reach"], 1500)
+
+    def test_mapear_medios_stakeholders_combina_fecha_iso_y_hora(self):
+        view = IngestionAPIView()
+        row = {
+            "titulo": "Titulo Stakeholder",
+            "resumen": "Contenido",
+            "fecha": "2025-09-29",
+            "hora": "08:30",
+            "autor": "Autor SH",
+            "audiencia": "200",
+            "url": "http://example.com/stakeholder",
+        }
+
+        registro = view._mapear_medios_twk(row, "stakeholders")
+
+        self.assertIsNotNone(registro["fecha"])
+        self.assertEqual(registro["fecha"].date(), date(2025, 9, 29))
+        self.assertEqual(registro["fecha"].time(), time(8, 30))
 
     @patch("apps.base.api.ingestion.Proyecto")
     def test_respuesta_incluye_conteo_de_duplicados(self, mock_proyecto):


### PR DESCRIPTION
## Summary
- actualizar los casos de prueba para Global News y Stakeholders con los formatos de fecha actualmente provistos por la ingestión

## Testing
- python manage.py test apps.base.tests.test_ingestion.IngestionAPITests

------
https://chatgpt.com/codex/tasks/task_e_68dea0a01348833396619cbf8cf655e6