### PR TITLE
Handle alert ordering with hour information

### DIFF
--- a/apps/whatsapp/tests.py
+++ b/apps/whatsapp/tests.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 from django.test import SimpleTestCase
 
 from apps.whatsapp.api.enviar_mensaje import enviar_alertas_automatico
+from apps.whatsapp.utils import ordenar_alertas_por_fecha
 
 
 class EnviarAlertasAutomaticoFechaTests(SimpleTestCase):
@@ -70,3 +71,26 @@ class EnviarAlertasAutomaticoFechaTests(SimpleTestCase):
 
         alerta_pasada = mock_formatear_mensaje.call_args[0][0]
         self.assertEqual(alerta_pasada["fecha_publicacion"], "2025-09-23 4:01:38 PM")
+
+
+class OrdenarAlertasPorFechaTests(SimpleTestCase):
+    def test_ordena_por_fecha_y_hora_cuando_estan_separadas(self):
+        alertas = [
+            {"id": "c", "fecha": "2024-01-03", "hora": "18:45"},
+            {"id": "b", "fecha": "2024-01-03", "hora": "08:15"},
+            {"id": "a", "fecha": "2024-01-02"},
+        ]
+
+        ordenadas = ordenar_alertas_por_fecha(alertas)
+
+        self.assertEqual([alerta["id"] for alerta in ordenadas], ["a", "b", "c"])
+
+    def test_ordena_usando_campo_time(self):
+        alertas = [
+            {"id": "primera", "fecha_publicacion": "2024-05-01", "time": "07:30"},
+            {"id": "segunda", "fecha_publicacion": "2024-05-01", "time": "19:10"},
+        ]
+
+        ordenadas = ordenar_alertas_por_fecha(alertas)
+
+        self.assertEqual([alerta["id"] for alerta in ordenadas], ["primera", "segunda"])

--- a/apps/whatsapp/utils.py
+++ b/apps/whatsapp/utils.py
@@ -1,31 +1,104 @@
 """Utilidades para el módulo de WhatsApp."""
 from __future__ import annotations
 
-from datetime import datetime, timezone as dt_timezone
+from datetime import date, datetime, time, timezone as dt_timezone
 from typing import Iterable, List, MutableMapping, Sequence
 
-from django.utils.dateparse import parse_datetime
+from django.utils.dateparse import parse_date, parse_datetime, parse_time
 
 
-def _obtener_fecha(alerta: MutableMapping, *, campo_fecha: str, campo_respaldo: str) -> datetime:
-    """Obtiene la fecha de la alerta intentando diferentes formatos."""
-    valor = alerta.get(campo_fecha) or alerta.get(campo_respaldo)
+def _parse_datetime_value(valor: object) -> datetime | None:
+    """Parses a value into a timezone-aware ``datetime`` when possible."""
 
     if isinstance(valor, datetime):
         if valor.tzinfo is None:
             return valor.replace(tzinfo=dt_timezone.utc)
         return valor
 
-    if isinstance(valor, str) and valor:
-        fecha = parse_datetime(valor)
-        if fecha:
-            if fecha.tzinfo is None:
-                return fecha.replace(tzinfo=dt_timezone.utc)
-            return fecha
-        try:
-            return datetime.fromisoformat(valor.replace("Z", "+00:00"))
-        except ValueError:
-            pass
+    if isinstance(valor, date):
+        return datetime.combine(valor, time.min).replace(tzinfo=dt_timezone.utc)
+
+    if isinstance(valor, str):
+        texto = valor.strip()
+        if texto:
+            fecha = parse_datetime(texto)
+            if fecha:
+                if fecha.tzinfo is None:
+                    return fecha.replace(tzinfo=dt_timezone.utc)
+                return fecha
+
+            fecha = parse_date(texto)
+            if fecha:
+                return datetime.combine(fecha, time.min).replace(tzinfo=dt_timezone.utc)
+
+            try:
+                fecha = datetime.fromisoformat(texto.replace("Z", "+00:00"))
+            except ValueError:
+                fecha = None
+            if fecha:
+                if fecha.tzinfo is None:
+                    return fecha.replace(tzinfo=dt_timezone.utc)
+                return fecha
+
+    return None
+
+
+def _parse_time_value(valor: object) -> time | None:
+    """Parses a value into a ``time`` instance when possible."""
+
+    if isinstance(valor, time):
+        return valor
+
+    if isinstance(valor, datetime):
+        return valor.time()
+
+    if isinstance(valor, str):
+        texto = valor.strip()
+        if not texto:
+            return None
+
+        parsed = parse_time(texto)
+        if parsed:
+            return parsed
+
+        for formato in ("%H:%M", "%H:%M:%S", "%I:%M %p", "%I:%M:%S %p"):
+            try:
+                return datetime.strptime(texto, formato).time()
+            except ValueError:
+                continue
+
+    return None
+
+
+def _obtener_fecha(
+    alerta: MutableMapping,
+    *,
+    campo_fecha: str,
+    campo_respaldo: str,
+    campos_hora: Sequence[str] = ("hora_publicacion", "hora", "time"),
+) -> datetime:
+    """Obtiene la fecha de la alerta intentando diferentes formatos."""
+
+    valor_fecha = alerta.get(campo_fecha)
+    if not valor_fecha:
+        valor_fecha = alerta.get(campo_respaldo)
+
+    fecha = _parse_datetime_value(valor_fecha)
+
+    hora_valor = next((alerta.get(campo) for campo in campos_hora if alerta.get(campo)), None)
+    if hora_valor is not None:
+        hora = _parse_time_value(hora_valor)
+        if hora is not None:
+            base = fecha or datetime.min.replace(tzinfo=dt_timezone.utc)
+            return base.replace(
+                hour=hora.hour,
+                minute=hora.minute,
+                second=hora.second,
+                microsecond=hora.microsecond,
+            )
+
+    if fecha is not None:
+        return fecha
 
     return datetime.min.replace(tzinfo=dt_timezone.utc)
 


### PR DESCRIPTION
## Summary
- update the WhatsApp alert ordering helper to parse standalone hour fields and build full datetimes
- add unit tests that cover ordering when alerts provide a separate hour or time field

## Testing
- PYTHONPATH=$PWD DJANGO_SETTINGS_MODULE=SistemaAlertas.settings pytest apps/whatsapp/tests.py::OrdenarAlertasPorFechaTests -q *(fails: Django apps aren't loaded when running the module directly in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e015b57d1c8333a7263073c21a5762