### PR TITLE
Ensure Global News ingestion uses provided Hora column

### DIFF
--- a/apps/base/api/ingestion.py
+++ b/apps/base/api/ingestion.py
@@ -790,7 +790,11 @@ class IngestionAPIView(APIView):
                 ["fecha", "published", "date"],
             )
             hora_raw = None
-            if provider_normalized != "stakeholders":
+            if provider_normalized == "global_news":
+                hora_raw = row.get("Hora") or row.get("hora")
+                if not self._valor_contiene_datos(hora_raw):
+                    hora_raw = None
+            if hora_raw is None and provider_normalized != "stakeholders":
                 hora_raw = self._obtener_primera_coincidencia(row, ["hora", "time"])
 
             if hora_raw is not None:

--- a/apps/base/api/ingestion.py
+++ b/apps/base/api/ingestion.py
@@ -778,28 +778,37 @@ class IngestionAPIView(APIView):
     ) -> Dict[str, Any]:
         provider_normalized = (provider or "").strip().lower()
         fecha = None
+        fecha_raw: Optional[Any] = None
+        hora_raw: Optional[Any] = None
+
+        if provider_normalized == "global_news":
+            hora_candidata = row.get("Hora") or row.get("hora")
+            if self._valor_contiene_datos(hora_candidata):
+                hora_raw = hora_candidata
+
         if provider_normalized == "medios":
             fecha = parsear_datetime(row.get("published"))
         elif provider_normalized == "global_news":
-            fecha = parsear_datetime(
-                self._obtener_primera_coincidencia(row, ["fecha"])
-            )
+            fecha_raw = self._obtener_primera_coincidencia(row, ["fecha"])
+            if hora_raw is not None:
+                fecha = combinar_fecha_hora(fecha_raw, hora_raw)
+            if fecha is None:
+                fecha = parsear_datetime(fecha_raw)
+
         if fecha is None:
-            fecha_raw = self._obtener_primera_coincidencia(
-                row,
-                ["fecha", "published", "date"],
-            )
-            hora_raw = None
-            if provider_normalized == "global_news":
-                hora_raw = row.get("Hora") or row.get("hora")
-                if not self._valor_contiene_datos(hora_raw):
-                    hora_raw = None
+            if fecha_raw is None:
+                fecha_raw = self._obtener_primera_coincidencia(
+                    row,
+                    ["fecha", "published", "date"],
+                )
+
             if hora_raw is None and provider_normalized != "stakeholders":
                 hora_raw = self._obtener_primera_coincidencia(row, ["hora", "time"])
 
             if hora_raw is not None:
                 fecha = combinar_fecha_hora(fecha_raw, hora_raw)
-            else:
+
+            if fecha is None:
                 fecha = parsear_datetime(fecha_raw)
         titulo = limpiar_texto(
             self._obtener_primera_coincidencia(

--- a/apps/base/api/utils.py
+++ b/apps/base/api/utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from datetime import date, datetime, time, timedelta
 from typing import Iterable as _Iterable
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
@@ -180,7 +182,17 @@ def parsear_hora(value: Any) -> Optional[time]:
     texto = str(value).strip()
     if not texto:
         return None
-    return parse_time(texto)
+    parsed = parse_time(texto)
+    if parsed:
+        return parsed
+
+    coincidencias = re.findall(r"\d{1,2}:\d{2}(?::\d{2})?", texto)
+    for coincidencia in coincidencias:
+        parsed_coincidencia = parse_time(coincidencia)
+        if parsed_coincidencia:
+            return parsed_coincidencia
+
+    return None
 
 
 def combinar_fecha_hora(fecha_value: Any, hora_value: Any) -> Optional[datetime]:

--- a/apps/base/tests/test_ingestion.py
+++ b/apps/base/tests/test_ingestion.py
@@ -559,6 +559,25 @@ class IngestionAPITests(SimpleTestCase):
         self.assertEqual(registro["reach"], 1500)
         self.assertEqual(registro["autor"], "Canal GN")
 
+    def test_mapear_medios_global_news_soporta_hora_duplicada(self):
+        view = IngestionAPIView()
+        row = {
+            "titulo": "Titulo GN",
+            "contenido": "Contenido GN",
+            "fecha": "2025-09-11",
+            "Hora": "05:59:25\n05:59:25",
+            "autor": "Autor GN",
+            "medio": "Canal GN",
+            "audiencia": "1500",
+            "url": "http://example.com/global-news",
+        }
+
+        registro = view._mapear_medios_twk(row, "global_news")
+
+        self.assertIsNotNone(registro["fecha"])
+        self.assertEqual(registro["fecha"].date(), date(2025, 9, 11))
+        self.assertEqual(registro["fecha"].time(), time(5, 59, 25))
+
     def test_mapear_medios_stakeholders_no_combina_fecha_iso_y_hora(self):
         view = IngestionAPIView()
         row = {

--- a/apps/base/tests/test_ingestion.py
+++ b/apps/base/tests/test_ingestion.py
@@ -578,6 +578,25 @@ class IngestionAPITests(SimpleTestCase):
         self.assertEqual(registro["fecha"].date(), date(2025, 9, 11))
         self.assertEqual(registro["fecha"].time(), time(5, 59, 25))
 
+    def test_mapear_medios_global_news_reemplaza_hora_de_fecha_iso(self):
+        view = IngestionAPIView()
+        row = {
+            "titulo": "Titulo GN",
+            "contenido": "Contenido GN",
+            "fecha": "2025-09-11 12:00:00 AM",
+            "Hora": "05:59:25",
+            "autor": "Autor GN",
+            "medio": "Canal GN",
+            "audiencia": "1500",
+            "url": "http://example.com/global-news",
+        }
+
+        registro = view._mapear_medios_twk(row, "global_news")
+
+        self.assertIsNotNone(registro["fecha"])
+        self.assertEqual(registro["fecha"].date(), date(2025, 9, 11))
+        self.assertEqual(registro["fecha"].time(), time(5, 59, 25))
+
     def test_mapear_medios_stakeholders_no_combina_fecha_iso_y_hora(self):
         view = IngestionAPIView()
         row = {


### PR DESCRIPTION
## Summary
- read the Global News time directly from the `Hora` column before falling back to lowercase names
- cover the Global News mapping with a regression test that exercises an uppercase `Hora` value containing duplicated timestamps

## Testing
- `pytest apps/base/tests/test_ingestion.py -k hora_duplicada` *(fails: Django settings are not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0368160d08333aa218a0e4bfbb5b3