### PR TITLE
Add Bright Data snapshot endpoint

### DIFF
--- a/apps/base/api/brightdata_trigger.py
+++ b/apps/base/api/brightdata_trigger.py
@@ -1,0 +1,61 @@
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from script.brightdata import buscar_interacciones
+
+
+class BrightDataSnapshotAPIView(APIView):
+    """Crea snapshots en Bright Data a partir de una o varias URLs."""
+
+    authentication_classes = []
+    permission_classes = []
+
+    def post(self, request):
+        urls = request.data.get("urls") or request.data.get("url")
+        red_social = request.data.get("red_social")
+
+        if not red_social:
+            return Response(
+                {"error": "Se requiere 'red_social' para seleccionar el dataset."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not urls:
+            return Response(
+                {"error": "Se requiere al menos una URL en 'urls' o 'url'."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if isinstance(urls, str):
+            urls = [urls]
+
+        if not isinstance(urls, (list, tuple)):
+            return Response(
+                {"error": "El campo 'urls' debe ser una lista de cadenas."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        snapshots = []
+        errores = []
+
+        for url in urls:
+            if not url:
+                errores.append({"url": url, "error": "URL vacía."})
+                continue
+
+            try:
+                snapshot_id = buscar_interacciones(url, red_social)
+            except ValueError as exc:
+                return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+            except Exception as exc:  # pragma: no cover - errores inesperados
+                errores.append({"url": url, "error": f"Error al solicitar snapshot: {exc}"})
+                continue
+
+            if snapshot_id:
+                snapshots.append({"url": url, "snapshot_id": snapshot_id})
+            else:
+                errores.append({"url": url, "error": "No se obtuvo snapshot_id"})
+
+        estado = status.HTTP_200_OK if snapshots else status.HTTP_502_BAD_GATEWAY
+        return Response({"snapshots": snapshots, "errores": errores}, status=estado)

--- a/apps/base/urls.py
+++ b/apps/base/urls.py
@@ -7,6 +7,7 @@ from apps.base.api.importar_redes import ImportarRedesAPIView
 from apps.base.api.formato_mensaje import CrearPlantillaAPIView , ListarPlantillasAPIView,CrearCamposPlantillaAPIView
 from apps.base.api.historial import HistorialEnviosListAPIView,HistorialEnviosDetailAPIView,ExportarHistorialExcelView
 from apps.base.api.ingestion import IngestionAPIView
+from apps.base.api.brightdata_trigger import BrightDataSnapshotAPIView
 from apps.base.api.procesar_alerta_existente import ProcesarAlertaExistenteAPIView
 
 from apps.base.api.login import (
@@ -44,5 +45,7 @@ urlpatterns = [
     path("exportar-historial/", ExportarHistorialExcelView.as_view(), name="exportar-historial"),
 
     path("procesar-alerta-existente/", ProcesarAlertaExistenteAPIView.as_view(), name="procesar-alerta-existente"),
+
+    path("brightdata/snapshot/", BrightDataSnapshotAPIView.as_view(), name="brightdata-snapshot"),
 
 ]


### PR DESCRIPTION
## Summary
- add an API endpoint to request Bright Data snapshots for provided URLs
- validate inputs and return collected snapshot identifiers and errors
- register the endpoint under the base API routes

## Testing
- python manage.py check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693239e404c88333a86b17de175002de)